### PR TITLE
2.0.0-alpha.2 + alpha.3: method-shadowing fix and unified rejection vocabulary

### DIFF
--- a/dist/SAM.js
+++ b/dist/SAM.js
@@ -248,6 +248,43 @@
     }
   };
 
+  // module-level clone so the recursion cannot be shadowed by a model data key
+  // named `clone` (issue #29)
+  const cloneState = state => {
+    const comps = state.__components;
+    const {
+      __components,
+      ...stateWithoutComps
+    } = state;
+
+    // Optimized cloning - avoid JSON.parse(JSON.stringify) for better performance
+    const cln = Array.isArray(stateWithoutComps) ? [...stateWithoutComps] : {
+      ...stateWithoutComps
+    };
+
+    // Deep clone nested objects
+    Object.keys(cln).forEach(key => {
+      const value = cln[key];
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        cln[key] = cloneState(value);
+      } else if (Array.isArray(value)) {
+        cln[key] = value.map(item => item && typeof item === 'object' ? cloneState(item) : item);
+      }
+    });
+    if (comps) {
+      cln.__components = {};
+      Object.keys(comps).forEach(key => {
+        const {
+          parent,
+          ...compWithoutParent
+        } = comps[key];
+        cln.__components[key] = Object.assign(cloneState(compWithoutParent), {
+          parent: cln
+        });
+      });
+    }
+    return cln;
+  };
   class Model {
     constructor(name) {
       this.__components = {};
@@ -344,46 +381,15 @@
       this.__eventQueue = [];
     }
     flush() {
-      if (this.continue() === false) {
+      // direct field access: a data key named `continue` must not shadow the check (#29)
+      if (this.__continue !== true) {
         var _this$__eventQueue;
         (_this$__eventQueue = this.__eventQueue) === null || _this$__eventQueue === void 0 || _this$__eventQueue.forEach(([event, data]) => events.emit(event, data));
         this.__eventQueue = [];
       }
     }
     clone(state = this) {
-      const comps = state.__components;
-      const {
-        __components,
-        ...stateWithoutComps
-      } = state;
-
-      // Optimized cloning - avoid JSON.parse(JSON.stringify) for better performance
-      const cln = Array.isArray(stateWithoutComps) ? [...stateWithoutComps] : {
-        ...stateWithoutComps
-      };
-
-      // Deep clone nested objects
-      Object.keys(cln).forEach(key => {
-        const value = cln[key];
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-          cln[key] = this.clone(value);
-        } else if (Array.isArray(value)) {
-          cln[key] = value.map(item => item && typeof item === 'object' ? this.clone(item) : item);
-        }
-      });
-      if (comps) {
-        cln.__components = {};
-        Object.keys(comps).forEach(key => {
-          const {
-            parent,
-            ...compWithoutParent
-          } = comps[key];
-          cln.__components[key] = Object.assign(this.clone(compWithoutParent), {
-            parent: cln
-          });
-        });
-      }
-      return cln;
+      return cloneState(state);
     }
     state(name, clone) {
       const prop = n => E(this[n]) ? this[n] : E(this.__components[n]) ? this.__components[n] : this;
@@ -393,7 +399,7 @@
       } else {
         state = prop(name);
       }
-      return clone && state ? this.clone(state) : state;
+      return clone && state ? cloneState(state) : state;
     }
   }
 
@@ -645,6 +651,11 @@
     let history;
     const model = new Model(instanceName);
 
+    // framework-internal Model method access, immune to data keys shadowing
+    // prototype methods (issue #29: a model key named 'state', 'clone', ...)
+    const invokeModel = (method, ...args) => Model.prototype[method].apply(model, args);
+    const safeFlush = m => m instanceof Model ? Model.prototype.flush.call(m) : typeof m.flush === 'function' ? m.flush() : undefined;
+
     // v2 (#21): declared, sealed model shape — SAM's VARIABLES
     let modelShape = null;
     const stepMutations = new Set();
@@ -714,6 +725,14 @@
     }) : model;
     const registerModelShape = shape => {
       modelShape = Object.assign(modelShape !== null && modelShape !== void 0 ? modelShape : {}, shape);
+      // #29: the framework is immune to data keys shadowing Model methods, but
+      // user code calling model.<key>() in render/naps would see data — flag it
+      if (devWarnings) {
+        const collisions = Object.keys(shape).filter(key => typeof Model.prototype[key] === 'function');
+        if (collisions.length > 0) {
+          console.warn("SAM: modelShape key(s) ".concat(collisions.map(k => "'".concat(k, "'")).join(', '), " shadow Model method(s) of the same name; the framework is unaffected, but calling model.").concat(collisions[0], "() in your own render/naps returns the data \u2014 use getState() for snapshots"));
+        }
+      }
       // validate the current observable state against the declared shape
       Object.keys(model).filter(key => key.indexOf('__') !== 0).forEach(key => {
         const violation = checkShapeWrite(modelShape, key, model[key]);
@@ -852,13 +871,13 @@
       }
     }];
     const reactors = [() => {
-      model.hasNext(history ? history.hasNext() : false);
+      invokeModel('hasNext', history ? history.hasNext() : false);
     }];
     const naps = [];
 
     // ancillary
-    let renderView = m => m.flush();
-    let _render = m => m.flush();
+    let renderView = m => safeFlush(m);
+    let _render = m => safeFlush(m);
     let storeRenderView = _render;
 
     // State Representation
@@ -869,9 +888,9 @@
 
         // render state representation (gated by nap)
         if (!naps.map(react).reduce(or, false)) {
-          renderView(clone ? model.clone() : model);
+          renderView(clone ? invokeModel('clone') : model);
         }
-        model.renderNextTime();
+        invokeModel('renderNextTime');
       } catch (err) {
         if (err.name === 'AssertionError' || isStrictError(err)) {
           throw err;
@@ -926,7 +945,7 @@
     let present = synchronize ? async (proposal, resolve) => {
       if (checkForOutOfOrder(proposal)) {
         beginStep(proposal);
-        model.resetEventQueue();
+        invokeModel('resetEventQueue');
         // accept proposal
         await Promise.all(acceptors.map(accept(proposal, stepApi)));
         storeBehavior(proposal);
@@ -955,18 +974,18 @@
 
     // SAM's internal acceptors
     const addInitialState = (initialState = {}) => {
-      model.update(initialState);
+      invokeModel('update', initialState);
       if (history) {
         history.snap(model, 0);
       }
-      model.resetBehavior();
+      invokeModel('resetBehavior');
     };
 
     // eslint-disable-next-line no-shadow
     const rollback = (conditions = []) => conditions.map(condition => model => () => {
       const isNotSafe = condition.expression(model);
       if (isNotSafe) {
-        model.log({
+        invokeModel('log', {
           error: {
             name: condition.name,
             model
@@ -974,17 +993,17 @@
         });
         // rollback if history is present
         if (history) {
-          model.update(history.last());
+          invokeModel('update', history.last());
           renderView(model);
         }
         return true;
       }
       return false;
     });
-    const isAllowed = action => (!model.__blockUnexpectedActions && model.allowedActions().length === 0 || model.allowedActions().map(a => typeof a === 'string' ? a === action.__actionName : a === action).reduce(or, false)) && !model.disallowedActions().map(a => typeof a === 'string' ? a === action.__actionName : a === action).reduce(or, false);
+    const isAllowed = action => (!model.__blockUnexpectedActions && invokeModel('allowedActions').length === 0 || invokeModel('allowedActions').map(a => typeof a === 'string' ? a === action.__actionName : a === action).reduce(or, false)) && !invokeModel('disallowedActions').map(a => typeof a === 'string' ? a === action.__actionName : a === action).reduce(or, false);
     const acceptLocalState = component => {
       if (component.name != null) {
-        model.setComponentState(component);
+        invokeModel('setComponentState', component);
       }
     };
 
@@ -1217,21 +1236,21 @@
     };
     const setRender = render => {
       const flushEventsAndRender = m => {
-        m.flush && m.flush();
+        safeFlush(m);
         render && render(m);
       };
       renderView = history ? wrap(flushEventsAndRender, s => history ? history.snap(s) : s) : flushEventsAndRender;
       _render = render;
     };
     const setLogger = l => {
-      model.setLogger(l);
+      invokeModel('setLogger', l);
     };
     const setHistory = h => {
       history = new History(h, {
         max
       });
-      model.hasNext(history.hasNext());
-      model.resetBehavior();
+      invokeModel('hasNext', history.hasNext());
+      invokeModel('resetBehavior');
       renderView = wrap(_render, s => history ? history.snap(s) : s);
     };
     const timetravel = (travel = {}) => {
@@ -1274,10 +1293,10 @@
       clear = false
     }) => {
       if (clear) {
-        model.clearAllowedActions();
+        invokeModel('clearAllowedActions');
       }
       if (actions.length > 0) {
-        model.addAllowedActions(actions);
+        invokeModel('addAllowedActions', actions);
       }
       return model.__allowedActions;
     };
@@ -1303,12 +1322,12 @@
         stepListener = listener;
       }).on(initialState, addInitialState).on(component, addComponent).on(render, setRender).on(travel, timetravel).on(logger, setLogger).on(check, setCheck).on(allowed, allowedActions).on(clearInterval, () => queue.clear()).on(event, addEventHandler);
       return {
-        hasNext: model.hasNext(),
-        hasError: model.hasError(),
-        errorMessage: model.errorMessage(),
-        error: model.error(),
+        hasNext: invokeModel('hasNext'),
+        hasError: invokeModel('hasError'),
+        errorMessage: invokeModel('errorMessage'),
+        error: invokeModel('error'),
         intents,
-        state: name => model.state(name, clone),
+        state: name => invokeModel('state', name, clone),
         getState,
         setState,
         lastStep,

--- a/lib/sam-instance.js
+++ b/lib/sam-instance.js
@@ -92,6 +92,13 @@ export default function (options = {}) {
   let history
   const model = new Model(instanceName)
 
+  // framework-internal Model method access, immune to data keys shadowing
+  // prototype methods (issue #29: a model key named 'state', 'clone', ...)
+  const invokeModel = (method, ...args) => Model.prototype[method].apply(model, args)
+  const safeFlush = (m) => (m instanceof Model
+    ? Model.prototype.flush.call(m)
+    : (typeof m.flush === 'function' ? m.flush() : undefined))
+
   // v2 (#21): declared, sealed model shape — SAM's VARIABLES
   let modelShape = null
   const stepMutations = new Set()
@@ -159,6 +166,14 @@ export default function (options = {}) {
 
   const registerModelShape = (shape) => {
     modelShape = Object.assign(modelShape ?? {}, shape)
+    // #29: the framework is immune to data keys shadowing Model methods, but
+    // user code calling model.<key>() in render/naps would see data — flag it
+    if (devWarnings) {
+      const collisions = Object.keys(shape).filter((key) => typeof Model.prototype[key] === 'function')
+      if (collisions.length > 0) {
+        console.warn(`SAM: modelShape key(s) ${collisions.map((k) => `'${k}'`).join(', ')} shadow Model method(s) of the same name; the framework is unaffected, but calling model.${collisions[0]}() in your own render/naps returns the data — use getState() for snapshots`)
+      }
+    }
     // validate the current observable state against the declared shape
     Object.keys(model)
       .filter((key) => key.indexOf('__') !== 0)
@@ -297,14 +312,14 @@ export default function (options = {}) {
   ]
   const reactors = [
     () => {
-      model.hasNext(history ? history.hasNext() : false)
+      invokeModel('hasNext', history ? history.hasNext() : false)
     }
   ]
   const naps = []
 
   // ancillary
-  let renderView = (m) => m.flush()
-  let _render = (m) => m.flush()
+  let renderView = (m) => safeFlush(m)
+  let _render = (m) => safeFlush(m)
   let storeRenderView = _render
 
   // State Representation
@@ -315,9 +330,9 @@ export default function (options = {}) {
 
       // render state representation (gated by nap)
       if (!naps.map(react).reduce(or, false)) {
-        renderView(clone ? model.clone() : model)
+        renderView(clone ? invokeModel('clone') : model)
       }
-      model.renderNextTime()
+      invokeModel('renderNextTime')
     } catch (err) {
       if (err.name === 'AssertionError' || isStrictError(err)) {
         throw err
@@ -379,7 +394,7 @@ export default function (options = {}) {
   let present = synchronize ? async (proposal, resolve) => {
     if (checkForOutOfOrder(proposal)) {
       beginStep(proposal)
-      model.resetEventQueue()
+      invokeModel('resetEventQueue')
       // accept proposal
       await Promise.all(acceptors.map(accept(proposal, stepApi)))
 
@@ -411,21 +426,21 @@ export default function (options = {}) {
 
   // SAM's internal acceptors
   const addInitialState = (initialState = {}) => {
-    model.update(initialState)
+    invokeModel('update', initialState)
     if (history) {
       history.snap(model, 0)
     }
-    model.resetBehavior()
+    invokeModel('resetBehavior')
   }
 
   // eslint-disable-next-line no-shadow
   const rollback = (conditions = []) => conditions.map((condition) => (model) => () => {
     const isNotSafe = condition.expression(model)
     if (isNotSafe) {
-      model.log({ error: { name: condition.name, model } })
+      invokeModel('log', { error: { name: condition.name, model } })
       // rollback if history is present
       if (history) {
-        model.update(history.last())
+        invokeModel('update', history.last())
         renderView(model)
       }
       return true
@@ -433,13 +448,13 @@ export default function (options = {}) {
     return false
   })
 
-  const isAllowed = (action) => ((!model.__blockUnexpectedActions && model.allowedActions().length === 0)
-                              || model.allowedActions()
+  const isAllowed = (action) => ((!model.__blockUnexpectedActions && invokeModel('allowedActions').length === 0)
+                              || invokeModel('allowedActions')
                                 .map((a) => (typeof a === 'string'
                                   ? a === action.__actionName
                                   : a === action))
                                 .reduce(or, false))
-                              && !model.disallowedActions()
+                              && !invokeModel('disallowedActions')
                                 .map((a) => (typeof a === 'string'
                                   ? a === action.__actionName
                                   : a === action))
@@ -447,7 +462,7 @@ export default function (options = {}) {
 
   const acceptLocalState = (component) => {
     if (component.name != null) {
-      model.setComponentState(component)
+      invokeModel('setComponentState', component)
     }
   }
 
@@ -669,7 +684,7 @@ export default function (options = {}) {
 
   const setRender = (render) => {
     const flushEventsAndRender = (m) => {
-      m.flush && m.flush()
+      safeFlush(m)
       render && render(m)
     }
     renderView = history ? wrap(flushEventsAndRender, (s) => (history ? history.snap(s) : s)) : flushEventsAndRender
@@ -677,13 +692,13 @@ export default function (options = {}) {
   }
 
   const setLogger = (l) => {
-    model.setLogger(l)
+    invokeModel('setLogger', l)
   }
 
   const setHistory = (h) => {
     history = new TimeTraveler(h, { max })
-    model.hasNext(history.hasNext())
-    model.resetBehavior()
+    invokeModel('hasNext', history.hasNext())
+    invokeModel('resetBehavior')
     renderView = wrap(_render, (s) => (history ? history.snap(s) : s))
   }
 
@@ -719,10 +734,10 @@ export default function (options = {}) {
 
   const allowedActions = ({ actions = [], clear = false }) => {
     if (clear) {
-      model.clearAllowedActions()
+      invokeModel('clearAllowedActions')
     }
     if (actions.length > 0) {
-      model.addAllowedActions(actions)
+      invokeModel('addAllowedActions', actions)
     }
     return model.__allowedActions
   }
@@ -750,12 +765,12 @@ export default function (options = {}) {
       .on(event, addEventHandler)
 
     return {
-      hasNext: model.hasNext(),
-      hasError: model.hasError(),
-      errorMessage: model.errorMessage(),
-      error: model.error(),
+      hasNext: invokeModel('hasNext'),
+      hasError: invokeModel('hasError'),
+      errorMessage: invokeModel('errorMessage'),
+      error: invokeModel('error'),
       intents,
-      state: (name) => model.state(name, clone),
+      state: (name) => invokeModel('state', name, clone),
       getState,
       setState,
       lastStep,

--- a/lib/sam-model.js
+++ b/lib/sam-model.js
@@ -3,6 +3,38 @@ import {
 } from './sam-utils'
 import events from './sam-events'
 
+// module-level clone so the recursion cannot be shadowed by a model data key
+// named `clone` (issue #29)
+const cloneState = (state) => {
+  const comps = state.__components
+  const { __components, ...stateWithoutComps } = state
+
+  // Optimized cloning - avoid JSON.parse(JSON.stringify) for better performance
+  const cln = Array.isArray(stateWithoutComps)
+    ? [...stateWithoutComps]
+    : { ...stateWithoutComps }
+
+  // Deep clone nested objects
+  Object.keys(cln).forEach((key) => {
+    const value = cln[key]
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      cln[key] = cloneState(value)
+    } else if (Array.isArray(value)) {
+      cln[key] = value.map((item) => (item && typeof item === 'object' ? cloneState(item) : item))
+    }
+  })
+
+  if (comps) {
+    cln.__components = {}
+
+    Object.keys(comps).forEach((key) => {
+      const { parent, ...compWithoutParent } = comps[key]
+      cln.__components[key] = Object.assign(cloneState(compWithoutParent), { parent: cln })
+    })
+  }
+  return cln
+}
+
 class Model {
   constructor(name) {
     this.__components = {}
@@ -119,40 +151,15 @@ class Model {
   }
 
   flush() {
-    if (this.continue() === false) {
+    // direct field access: a data key named `continue` must not shadow the check (#29)
+    if (this.__continue !== true) {
       this.__eventQueue?.forEach(([event, data]) => events.emit(event, data))
       this.__eventQueue = []
     }
   }
 
   clone(state = this) {
-    const comps = state.__components
-    const { __components, ...stateWithoutComps } = state
-
-    // Optimized cloning - avoid JSON.parse(JSON.stringify) for better performance
-    const cln = Array.isArray(stateWithoutComps)
-      ? [...stateWithoutComps]
-      : { ...stateWithoutComps }
-
-    // Deep clone nested objects
-    Object.keys(cln).forEach((key) => {
-      const value = cln[key]
-      if (value && typeof value === 'object' && !Array.isArray(value)) {
-        cln[key] = this.clone(value)
-      } else if (Array.isArray(value)) {
-        cln[key] = value.map((item) => (item && typeof item === 'object' ? this.clone(item) : item))
-      }
-    })
-
-    if (comps) {
-      cln.__components = {}
-
-      Object.keys(comps).forEach((key) => {
-        const { parent, ...compWithoutParent } = comps[key]
-        cln.__components[key] = Object.assign(this.clone(compWithoutParent), { parent: cln })
-      })
-    }
-    return cln
+    return cloneState(state)
   }
 
   state(name, clone) {
@@ -163,7 +170,7 @@ class Model {
     } else {
       state = prop(name)
     }
-    return clone && state ? this.clone(state) : state
+    return clone && state ? cloneState(state) : state
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive-fab/sam-pattern",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0-alpha.2",
   "description": "SAM Pattern library",
   "main": "./dist/SAM.js",
   "scripts": {

--- a/test/v2/method-shadowing.test.js
+++ b/test/v2/method-shadowing.test.js
@@ -1,0 +1,131 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+const { expect } = require('chai')
+
+const { default: createInstance } = require('../../lib/sam-instance')
+
+/**
+ * Captures console.warn output for the duration of a test.
+ * @returns {{ messages: string[], restore: function(): void }}
+ */
+const stubWarn = () => {
+  const messages = []
+  const original = console.warn
+  console.warn = (...args) => messages.push(args.join(' '))
+  return { messages, restore: () => { console.warn = original } }
+}
+
+/**
+ * The Polygraph repro: a turnstile whose primary control-state key is named
+ * `state` — the most common field name in real state machines. Data keys must
+ * never shadow the framework's own Model methods (issue #29).
+ */
+const turnstile = (name, options = {}) => {
+  const instance = createInstance({ strict: true, instanceName: name, ...options })
+  const control = instance({
+    initialState: { state: 'LOCKED', coins: 0 },
+    component: {
+      modelShape: {
+        state: { type: 'string' },
+        coins: { type: 'number' }
+      },
+      actions: {
+        Coin: () => ({ coin: true }),
+        Push: () => ({ push: true })
+      },
+      acceptors: {
+        Coin: model => (p, { reject }) => {
+          if (model.state === 'UNLOCKED') return reject('already unlocked')
+          model.state = 'UNLOCKED'
+          model.coins += 1
+          return undefined
+        },
+        Push: model => (p, { reject }) => {
+          if (model.state === 'LOCKED') return reject('locked')
+          model.state = 'LOCKED'
+          return undefined
+        }
+      }
+    }
+  })
+  return { instance, control }
+}
+
+describe('v2 — model data keys must not shadow Model methods (#29)', () => {
+  it('should keep the state(name) accessor working with a data key named `state`', async () => {
+    const { instance, control } = turnstile('v2shadowState')
+    expect(control.state('state')).to.equal('LOCKED')
+    await control.intents.Coin()
+    expect(instance({}).state('state')).to.equal('UNLOCKED')
+    expect(instance({}).state('coins')).to.equal(1)
+  })
+
+  it('should keep the no-argument state() accessor (error-slot idiom) working', async () => {
+    const { instance, control } = turnstile('v2shadowAccessor')
+    const modelView = instance({}).state()
+    expect(modelView.state).to.equal('LOCKED')
+    await control.intents.Push() // rejected: locked
+    expect(instance({}).lastStep().classification).to.equal('rejected')
+    expect(instance({}).hasError).to.equal(false)
+  })
+
+  it('should render and getState correctly despite the shadowing key', async () => {
+    let rendered
+    const instance = createInstance({ strict: true, instanceName: 'v2shadowRender' })
+    const control = instance({
+      initialState: { state: 'LOCKED', coins: 0 },
+      component: {
+        modelShape: { state: { type: 'string' }, coins: { type: 'number' } },
+        actions: { Coin: () => ({ coin: true }) },
+        acceptors: {
+          Coin: model => () => {
+            model.state = 'UNLOCKED'
+            model.coins += 1
+          }
+        }
+      },
+      render: s => { rendered = s.coins }
+    })
+    await control.intents.Coin()
+    expect(rendered).to.equal(1)
+    expect(control.getState()).to.deep.equal({ state: 'UNLOCKED', coins: 1 })
+    control.setState({ state: 'LOCKED', coins: 0 })
+    expect(control.getState()).to.deep.equal({ state: 'LOCKED', coins: 0 })
+  })
+
+  it('should survive shadowing of other Model methods (clone, flush, continue) in cloned renders', async () => {
+    let rendered
+    const instance = createInstance({ strict: true, clone: true, instanceName: 'v2shadowClone' })
+    const control = instance({
+      initialState: {
+        state: 'LOCKED', clone: 'data', flush: 'data', continue: 'data'
+      },
+      component: {
+        modelShape: {
+          state: { type: 'string' },
+          clone: { type: 'string' },
+          flush: { type: 'string' },
+          continue: { type: 'string' }
+        },
+        actions: { Coin: () => ({ coin: true }) },
+        acceptors: { Coin: model => () => { model.state = 'UNLOCKED' } }
+      },
+      render: s => { rendered = s.state }
+    })
+    await control.intents.Coin()
+    expect(rendered).to.equal('UNLOCKED')
+    expect(control.getState().clone).to.equal('data')
+  })
+
+  it('should warn at shape registration about method-name collisions in strict mode', () => {
+    const warn = stubWarn()
+    try {
+      turnstile('v2shadowWarn')
+    } finally {
+      warn.restore()
+    }
+    const output = warn.messages.join(' ')
+    expect(output).to.include("'state'")
+    expect(output).to.include('getState')
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #27 — carries the two alphas that landed on `v2` after the merge.

**alpha.2 — fixes #28 and fixes #29** (same report; #29 is the duplicate): a model key named `state` — the most common control-state field name, and the primary control-state key in most Polygraph contracts — replaced `Model.prototype.state` on the instance, so `instance({}).state()` threw `TypeError`. Fixed structurally (option (a) from #28):

- sam-instance invokes Model methods via `Model.prototype.<m>.apply(model, …)` (`invokeModel`) for all framework calls and accessors — `state()`/`hasError`/rendering/time-travel work regardless of data key names.
- `Model.flush`/`clone` no longer call shadowable siblings (direct `__continue` check; module-level `cloneState`).
- Strict mode warns at `modelShape` registration on method-name collisions (`getState()` is the safe accessor for user code).
- The Polygraph try/catch-plus-`getState()` workaround can be dropped once this merges.

**alpha.3 — fixes #31**: an acceptor recording `model.__error` for a refused proposal (sam-fsm's default path, the general v1 rejection idiom) classified as `unhandled` and warned — false positives for tooling that treats unexplained unhandled steps as findings. Now an `__error`-slot write during a non-mutating step classifies **`rejected`** with the error text as `rejections[0].reason`, unifying v1 `__error` writes and v2 `reject(reason)` under one observable vocabulary. Mutation wins (error stays readable); stale slot values don't re-classify later steps; `unhandled` now means exactly: fired, no mutation, no rejection, no error.

## Test plan

- 222 passing: 5 shadowing tests (Polygraph turnstile repro + clone-mode `clone`/`flush`/`continue` data keys) and 5 error-slot classification tests (fsm default-path shape, mutation-wins, Error objects, stale-slot, true no-op)
- sam-fsm suite re-verified against this build (62 passing) — guarded transitions no longer emit "unhandled proposal" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5uDb8Asnn6UwUVtDQQpdL