### PR TITLE
2.0.0-alpha.3: classify error-slot writes during a step as rejected

### DIFF
--- a/dist/SAM.js
+++ b/dist/SAM.js
@@ -684,6 +684,7 @@
     // them so they classify as mutated (deep) instead of a false "unhandled"
     let stepBeforeSnapshot;
     let stepDeepChange = false;
+    let stepErrorBefore;
     const beginStep = proposal => {
       var _proposal$__actionNam;
       currentIntentName = (_proposal$__actionNam = proposal.__actionName) !== null && _proposal$__actionNam !== void 0 ? _proposal$__actionNam : null;
@@ -692,6 +693,7 @@
       stepRejections.length = 0;
       stepDeepChange = false;
       stepBeforeSnapshot = strict && currentIntentName != null ? display(model) : undefined;
+      stepErrorBefore = model.__error;
     };
 
     // strict mode hands acceptors/reactors/naps a sealed view of the model:
@@ -792,6 +794,17 @@
     const endStep = () => {
       if (stepBeforeSnapshot !== undefined && stepMutations.size === 0 && stepRejections.length === 0) {
         stepDeepChange = display(model) !== stepBeforeSnapshot;
+      }
+      // #31: an __error-slot write during a non-mutating step is the v1
+      // rejection idiom — classify it as rejected with the error text as the
+      // reason, unifying it with reject(reason) under one observable vocabulary
+      // (a step that also mutates classifies mutated; the error stays readable)
+      if (currentIntentName != null && stepRejections.length === 0 && stepMutations.size === 0 && !stepDeepChange && model.__error != null && model.__error !== stepErrorBefore) {
+        var _model$__error$messag, _model$__error;
+        stepRejections.push({
+          intent: currentIntentName,
+          reason: (_model$__error$messag = (_model$__error = model.__error) === null || _model$__error === void 0 ? void 0 : _model$__error.message) !== null && _model$__error$messag !== void 0 ? _model$__error$messag : String(model.__error)
+        });
       }
       const step = lastStep();
       if (devWarnings && strict && step.intent != null && step.classification === 'unhandled') {

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -79,6 +79,8 @@ acceptors: {
 
 `instance({}).lastStep()` returns `{ intent, mutations, writes, rejections, classification }` where classification is `mutated | rejected | identity-by-mutation | unhandled` — every no-op step is mechanically explainable. Strict mode warns on `unhandled` (intent fired, nothing mutated, nothing rejected). Subscribe a harness with `instance({ stepListener: step => ... })`.
 
+The v1 rejection idiom is unified into the same vocabulary (since 2.0.0-alpha.3): an acceptor that records `model.__error` during a non-mutating step classifies as `rejected` with the error text as `rejections[0].reason` — consumers of `lastStep()` need no version-specific branching. A step that writes `__error` *and* mutates classifies `mutated` (the error stays readable in the slot); `unhandled` means exactly one thing: the intent fired and the machine neither mutated, nor rejected, nor recorded an error.
+
 ## Step 4 — key acceptors by action (#23)
 
 v1 broadcast acceptors (every acceptor sees every proposal) still work, but the keyed form makes the framework do the binding — acceptor bodies contain only guards and mutations, and the switch-over-action-types monolith is inexpressible:

--- a/lib/sam-instance.js
+++ b/lib/sam-instance.js
@@ -125,6 +125,8 @@ export default function (options = {}) {
   let stepBeforeSnapshot
   let stepDeepChange = false
 
+  let stepErrorBefore
+
   const beginStep = (proposal) => {
     currentIntentName = proposal.__actionName ?? null
     stepMutations.clear()
@@ -132,6 +134,7 @@ export default function (options = {}) {
     stepRejections.length = 0
     stepDeepChange = false
     stepBeforeSnapshot = strict && currentIntentName != null ? display(model) : undefined
+    stepErrorBefore = model.__error
   }
 
   // strict mode hands acceptors/reactors/naps a sealed view of the model:
@@ -238,6 +241,19 @@ export default function (options = {}) {
   const endStep = () => {
     if (stepBeforeSnapshot !== undefined && stepMutations.size === 0 && stepRejections.length === 0) {
       stepDeepChange = display(model) !== stepBeforeSnapshot
+    }
+    // #31: an __error-slot write during a non-mutating step is the v1
+    // rejection idiom — classify it as rejected with the error text as the
+    // reason, unifying it with reject(reason) under one observable vocabulary
+    // (a step that also mutates classifies mutated; the error stays readable)
+    if (currentIntentName != null
+        && stepRejections.length === 0
+        && stepMutations.size === 0 && !stepDeepChange
+        && model.__error != null && model.__error !== stepErrorBefore) {
+      stepRejections.push({
+        intent: currentIntentName,
+        reason: model.__error?.message ?? String(model.__error)
+      })
     }
     const step = lastStep()
     if (devWarnings && strict && step.intent != null && step.classification === 'unhandled') {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognitive-fab/sam-pattern",
-  "version": "2.0.0-alpha.2",
+  "version": "2.0.0-alpha.3",
   "description": "SAM Pattern library",
   "main": "./dist/SAM.js",
   "scripts": {

--- a/test/v2/error-slot.test.js
+++ b/test/v2/error-slot.test.js
@@ -1,0 +1,149 @@
+/* eslint-disable no-unused-expressions */
+/* eslint-disable no-undef */
+const { expect } = require('chai')
+
+const { default: createInstance } = require('../../lib/sam-instance')
+
+/**
+ * Captures console.warn output for the duration of a test.
+ * @returns {{ messages: string[], restore: function(): void }}
+ */
+const stubWarn = () => {
+  const messages = []
+  const original = console.warn
+  console.warn = (...args) => messages.push(args.join(' '))
+  return { messages, restore: () => { console.warn = original } }
+}
+
+/**
+ * A clock in the v1 rejection idiom: invalid transitions record model.__error
+ * (the sam-fsm default path) instead of calling reject(). Issue #31 unifies
+ * this with v2 rejections in the step classifier.
+ */
+const v1StyleClock = (name) => {
+  const instance = createInstance({ strict: true, instanceName: name })
+  const control = instance({
+    initialState: { pc: 'TICKED' },
+    component: {
+      modelShape: { pc: { type: 'string' } },
+      actions: {
+        TICK: () => ({ tick: true }),
+        TOCK: () => ({ tock: true })
+      },
+      acceptors: [
+        model => ({ tick, tock }) => {
+          if (tick) {
+            if (model.pc === 'TICKED') {
+              model.__error = 'unexpected action TICK for state: TICKED'
+              return
+            }
+            model.pc = 'TICKED'
+          }
+          if (tock) {
+            if (model.pc === 'TOCKED') {
+              model.__error = 'unexpected action TOCK for state: TOCKED'
+              return
+            }
+            model.pc = 'TOCKED'
+          }
+        }
+      ]
+    }
+  })
+  return { instance, control }
+}
+
+describe('v2 — error-slot writes classify as rejected (#31)', () => {
+  it('should classify a v1-style __error write as rejected with the error text as reason', async () => {
+    const { instance, control } = v1StyleClock('v2errRejected')
+    const warn = stubWarn()
+    try {
+      await control.intents.TICK() // invalid from TICKED
+    } finally {
+      warn.restore()
+    }
+    const step = instance({}).lastStep()
+    expect(step.classification).to.equal('rejected')
+    expect(step.rejections).to.deep.equal([
+      { intent: 'TICK', reason: 'unexpected action TICK for state: TICKED' }
+    ])
+    expect(warn.messages.join(' ')).to.not.include('unhandled proposal')
+    expect(instance({}).state('pc')).to.equal('TICKED')
+  })
+
+  it('should classify mutated when a step writes __error AND mutates observable state', async () => {
+    const instance = createInstance({ strict: true, instanceName: 'v2errMutated' })
+    const control = instance({
+      initialState: { count: 0 },
+      component: {
+        modelShape: { count: { type: 'number' } },
+        actions: { Increment: () => ({ increment: 1 }) },
+        acceptors: [
+          model => ({ increment }) => {
+            if (increment != null) {
+              model.count += increment
+              model.__error = 'partial acceptance note'
+            }
+          }
+        ]
+      }
+    })
+    await control.intents.Increment()
+    const step = instance({}).lastStep()
+    expect(step.classification).to.equal('mutated')
+    expect(step.rejections).to.deep.equal([])
+    // the error remains readable in the slot
+    expect(instance({}).hasError).to.equal(true)
+  })
+
+  it('should use the message of Error objects as the rejection reason', async () => {
+    const instance = createInstance({ strict: true, instanceName: 'v2errObject' })
+    const control = instance({
+      initialState: { pc: 'TICKED' },
+      component: {
+        modelShape: { pc: { type: 'string' } },
+        actions: { TICK: () => ({ tick: true }) },
+        acceptors: [
+          model => ({ tick }) => {
+            if (tick) {
+              model.__error = new Error('guard refused the proposal')
+            }
+          }
+        ]
+      }
+    })
+    await control.intents.TICK()
+    const step = instance({}).lastStep()
+    expect(step.classification).to.equal('rejected')
+    expect(step.rejections[0].reason).to.equal('guard refused the proposal')
+  })
+
+  it('should still classify a true no-op (no write, no reject, no error) as unhandled', async () => {
+    const instance = createInstance({ strict: true, instanceName: 'v2errNoop' })
+    const control = instance({
+      initialState: { count: 0 },
+      component: {
+        modelShape: { count: { type: 'number' } },
+        actions: { Noop: () => ({ noop: true }) },
+        acceptors: [() => () => null]
+      }
+    })
+    const warn = stubWarn()
+    try {
+      await control.intents.Noop()
+    } finally {
+      warn.restore()
+    }
+    expect(instance({}).lastStep().classification).to.equal('unhandled')
+    expect(warn.messages.join(' ')).to.include('unhandled proposal')
+  })
+
+  it('should not re-classify later steps from a stale error left in the slot', async () => {
+    const { instance, control } = v1StyleClock('v2errStale')
+    await control.intents.TICK() // rejected, __error set and left in the slot
+    await control.intents.TOCK() // valid transition, does not clear __error
+    const step = instance({}).lastStep()
+    expect(step.classification).to.equal('mutated')
+    expect(step.rejections).to.deep.equal([])
+  })
+})


### PR DESCRIPTION
## Summary

Follow-up to #30, which was merged while this commit was landing on `v2` (same race as #27 → #30) — master got alpha.2 only; this carries alpha.3.

Fixes #31: an acceptor recording `model.__error` for a refused proposal (sam-fsm's default path, the general v1 rejection idiom) classified as `unhandled` and warned — false positives for tooling that treats unexplained unhandled steps as findings (Polygraph). Now an `__error`-slot write during a non-mutating step classifies **`rejected`** with the error text as `rejections[0].reason`, unifying v1 `__error` writes and v2 `reject(reason)` under one observable vocabulary:

- Mutation wins: a step that writes `__error` and mutates classifies `mutated`; the error stays readable in the slot.
- Stale errors left in the slot do not re-classify later steps (compared against the slot's value at `beginStep`).
- `unhandled` now means exactly: fired, no mutation, no rejection, no error.
- MIGRATION.md documents the unified vocabulary.

Note for eval harnesses: this changes step-classification semantics — regenerate expected-count baselines when re-vendoring.

## Test plan

- 222 passing, incl. 5 new tests: the fsm default-path shape (`unexpected action X for state: Y` as rejection reason), mutation-wins, Error objects, stale-slot, true no-op
- sam-fsm suite re-verified (62 passing) — guarded transitions no longer emit "unhandled proposal" warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5uDb8Asnn6UwUVtDQQpdL